### PR TITLE
feat: add basic docker config and instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.12
+
+COPY . .
+
+RUN pip install -r requirements.txt
+
+RUN playwright install chromium
+
+ENV LIBRE_CRAWL_DATA_PATH=/data
+
+VOLUME [ "/data" ]
+
+CMD ["python", "main.py", "-l"]

--- a/README.md
+++ b/README.md
@@ -116,6 +116,22 @@ LibreCrawl supports multiple concurrent users with isolated sessions:
 - `src/settings_manager.py` - Configuration management
 - `web/` - Frontend interface files
 
+## Docker
+
+Build the docker container
+
+```bash
+docker build -t libre-crawl:latest .
+```
+
+Run the container, ensuring you attach a volume for the database
+
+```bash
+docker run -v /path/to/data:/data -p 5000:5000 libre-crawl:latest
+```
+
+Access at the default location: http://localhost:5000
+
 ## License
 
 MIT License - see LICENSE file for details.

--- a/src/auth_db.py
+++ b/src/auth_db.py
@@ -9,7 +9,8 @@ from datetime import datetime
 from contextlib import contextmanager
 
 # Database file location
-DB_FILE = 'users.db'
+DATA_PATH = os.environ['LIBRE_CRAWL_DATA_PATH'] or os.getcwd()
+DB_FILE = os.path.join(DATA_PATH, 'users.db')
 
 @contextmanager
 def get_db():


### PR DESCRIPTION
Gets a start on https://github.com/PhialsBasement/LibreCrawl/issues/8

Really basic and really just enough for me to test it locally real quick.

Does tweak the database connection info slightly, allowing for a configurable data-path to store the `users.db` file needed to register users. This was needed for docker to mount a volume.

There is a lot more optimization to do with the Dockerfile, such as multi-stage builders, proper labels and port declarations, etc.

Again this is 15minutes of effort to get a dockerfile working for new users to try this out quickly.