### PR TITLE
Fix: resume fails for stopped and failed crawls

### DIFF
--- a/src/crawler.py
+++ b/src/crawler.py
@@ -386,7 +386,7 @@ class WebCrawler:
             if not crawl_data:
                 return False, "Cannot resume this crawl - not found"
 
-            if crawl_data['status'] not in ['paused', 'failed', 'running']:
+            if crawl_data['status'] not in ['paused', 'failed', 'running', 'stopped']:
                 return False, f"Cannot resume crawl with status: {crawl_data['status']}"
 
             # Verify user owns this crawl (if not guest)


### PR DESCRIPTION
Only "paused" and "running" statuses were allowed in the resume logic. Stopped and failed crawls returned a misleading "Cannot resume crawl with status: stopped" error despite being resumable.

Added "stopped" and "failed" to the list of resumable statuses.