### PR TITLE
Fix: stop_crawl() overwrites "completed" status

### DIFF
--- a/src/crawler.py
+++ b/src/crawler.py
@@ -331,8 +331,11 @@ class WebCrawler:
         # Save final data to database
         if self.db_save_enabled and self.crawl_id:
             self._save_batch_to_db(force=True)
-            from src.crawl_db import set_crawl_status
-            set_crawl_status(self.crawl_id, 'stopped')
+            from src.crawl_db import get_crawl_by_id, set_crawl_status
+            crawl = get_crawl_by_id(self.crawl_id)
+            # Don't overwrite 'completed' status (e.g. from cleanup thread)
+            if crawl and crawl['status'] != 'completed':
+                set_crawl_status(self.crawl_id, 'stopped')
 
         # Clean up JavaScript resources if enabled
         if self.js_renderer:


### PR DESCRIPTION
Race condition: the cleanup thread calls stop_crawl() after a crawl has already been marked "completed", changing its status back to "stopped".

Added a status check before overwriting — if the crawl is already "completed", leave it alone.