### PR TITLE
Fix: hide Resume button on completed crawls

### DIFF
--- a/web/static/js/dashboard.js
+++ b/web/static/js/dashboard.js
@@ -55,7 +55,7 @@ async function openDashboard() {
                     <td><span style="color: ${statusColor};">${status}</span></td>
                     <td style="white-space: nowrap;">
                         <button class="btn btn-primary" style="margin-right: 5px; padding: 6px 12px; font-size: 13px;" onclick="loadCrawlFromDashboard(${crawl.id})">Load</button>
-                        <button class="btn btn-secondary" style="margin-right: 5px; padding: 6px 12px; font-size: 13px;" onclick="resumeCrawlFromDashboard(${crawl.id})">Resume</button>
+                        ${['paused', 'failed', 'running', 'stopped'].includes(status) ? `<button class="btn btn-secondary" style="margin-right: 5px; padding: 6px 12px; font-size: 13px;" onclick="resumeCrawlFromDashboard(${crawl.id})">Resume</button>` : ''}
                         <button class="btn btn-danger" style="padding: 6px 12px; font-size: 13px;" onclick="deleteCrawlFromDashboard(${crawl.id})">Delete</button>
                     </td>
                 </tr>


### PR DESCRIPTION
The Resume button was shown for completed crawls, but resuming a completed crawl always fails. Only render the button for statuses that can actually be resumed: paused, failed, running, and stopped.