### PR TITLE
Fix: REGISTRATION_DISABLED and DISABLE_GUEST env vars not read

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,7 +34,7 @@ parser.add_argument('--disable-guest', '-dg', action='store_true',
 args = parser.parse_args()
 
 LOCAL_MODE = args.local
-DISABLE_REGISTER = args.disable_register
+DISABLE_REGISTER = args.disable_register or os.getenv('REGISTRATION_DISABLED', '').lower() in ('true', '1', 'yes')
 DISABLE_GUEST = args.disable_guest or os.getenv('DISABLE_GUEST', '').lower() in ('true', '1', 'yes')
 
 app = Flask(__name__, template_folder='web/templates', static_folder='web/static')


### PR DESCRIPTION
Only the CLI arguments (--disable-register, --disable-guest) were checked. The environment variable path was missing, so setting REGISTRATION_DISABLED=true or DISABLE_GUEST=true had no effect.

Added os.getenv() fallback for both flags, accepting "true", "1", or "yes".