### PR TITLE
feat: allow configuring external port via environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@
 # - 0.0.0.0 = all interfaces (production, accessible from network)
 HOST_BINDING=127.0.0.1
 
+# The port binding for the application
+EXTERNAL_PORT=5000
+
 # Local mode - enables auto-login with admin access, no rate limits
 # Set to "true" for local development, "false" for production
 LOCAL_MODE=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       # In local mode: only localhost (127.0.0.1:5000)
       # In production mode: all interfaces (0.0.0.0:5000) for LAN/WAN access
-      - "${HOST_BINDING:-127.0.0.1}:5000:5000"
+      - "${HOST_BINDING:-127.0.0.1}:${EXTERNAL_PORT:-5000}:5000"
     volumes:
       # Persist the user database and settings
       - ./data:/app/data


### PR DESCRIPTION
Adds support to specify the `EXTERNAL_PORT` to bind to. Falls back to 5000 if `EXTERNAL_PORT` is not set.

Port 5000 would conflict with [Synology NAS](https://kb.synology.com/en-us/DSM/tutorial/What_network_ports_are_used_by_Synology_services) if installed there.