### PR TITLE
chore: add .env to .gitignore to prevent credential leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .claude/settings.local.json
 users.db
 data/*.db
+
+.env


### PR DESCRIPTION
Hello! 👋

I noticed that the .env file wasn't included in the .gitignore. I have added it to prevent any accidental leaks of sensitive credentials (API keys, database URLs, etc.) by contributors.

Let me know if everything looks good!