### PR TITLE
Read SECRET_KEY from environment variable

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,7 +46,9 @@ DEMO_MODE = args.demo or os.getenv('DEMO_MODE', '').lower() in ('true', '1', 'ye
 SKIP_AUTH = args.dangerously_skip_auth or os.getenv('DANGEROUSLY_SKIP_AUTH', '').lower() in ('true', '1', 'yes')
 
 app = Flask(__name__, template_folder='web/templates', static_folder='web/static')
-app.secret_key = 'librecrawl-secret-key-change-in-production'  # TODO: Use environment variable in production
+app.secret_key = os.environ.get('SECRET_KEY') or secrets.token_hex(32)
+if not os.environ.get('SECRET_KEY'):
+    print('⚠️  WARNING: SECRET_KEY env var not set — using ephemeral random key; sessions will not survive container restart.', flush=True)
 
 # Enable compression for all responses
 Compress(app)


### PR DESCRIPTION
Resolves the TODO on line 49 — `app.secret_key` was hardcoded to a value visible in the public repo, meaning every deployment using upstream `main.py` unchanged shares the same Flask session-signing key. With that key public, anyone can forge a valid signed session cookie (including `tier=admin`) for any LibreCrawl instance.

This PR reads `SECRET_KEY` from `os.environ` instead. Falls back to an ephemeral random key (`secrets.token_hex(32)`) with a stderr warning so the app still runs if the var isn't set in dev/test, but operators get a clear signal that they should set one in production.

### Behavior
- **`SECRET_KEY` env set:** signed sessions persist across restarts (production-ready)
- **`SECRET_KEY` env unset:** random key generated at startup with warning; sessions reset on container restart
- No breaking change for anyone — instances that ignore the env var keep working, just with the warning until they configure it

### Test
Deployed in a private fork behind Traefik with a real 32-byte hex key set via Docker env — sessions sign + verify normally, key is no longer in the repo, restart preserves login because env is stable.

### Notes
`os` and `secrets` are already imported at the top of `main.py` — no new imports needed.