### PR TITLE
fix: ensure data directory exists before init_db call (#65)

### DIFF
--- a/main.py
+++ b/main.py
@@ -54,6 +54,9 @@ if not os.environ.get('SECRET_KEY'):
 # Enable compression for all responses
 Compress(app)
 
+# Ensure data directory exists before initializing the database
+os.makedirs("data", exist_ok=True)
+
 # Initialize database on startup
 init_db()
 

--- a/start-librecrawl.bat
+++ b/start-librecrawl.bat
@@ -1,5 +1,6 @@
 @echo off
 
+if not exist data mkdir data
 echo Checking for Docker...
 docker --version 2>nul
 if errorlevel 1 goto nodocker

--- a/start-librecrawl.sh
+++ b/start-librecrawl.sh
@@ -2,6 +2,7 @@
 
 # Start LibreCrawl - tries Docker first, falls back to Python
 
+mkdir -p data
 echo "Checking for Docker..."
 if command -v docker &> /dev/null && command -v docker compose &> /dev/null; then
     echo "Docker found! Starting LibreCrawl with Docker..."


### PR DESCRIPTION
## Problem

`sqlite3.connect()` fails with `unable to open database file` on fresh installs where the `data/` directory does not exist. This happens with both Docker (bind mount creates `./data` as root, container user can't write) and bare Python (no `data/` directory at all).

Reported in #65.

## Fix

3 files changed, 5 insertions added — ensures `data/` exists before any database operation:

| File | Change |
|------|--------|
| `main.py` | `os.makedirs("data", exist_ok=True)` before `init_db()` call |
| `start-librecrawl.sh` | `mkdir -p data` at script start |
| `start-librecrawl.bat` | `if not exist data mkdir data` at script start |

`os.makedirs()` was already present inside `src/auth_db.py`'s `init_db()`, but the directory must exist before `init_db()` is reached. The startup scripts additionally ensure Docker bind mounts a pre-created directory with correct host-side permissions.

## Validation

- `git diff --stat`: 3 files, 5 insertions, 0 deletions
- Clean targeted changes, no whitespace or line-ending noise