### PR TITLE
docs: add AI / MCP integration section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ LibreCrawl will ***always*** be free and open source. If it's replacing your $25
 
 LibreCrawl crawls websites and gives you detailed information about pages, links, SEO elements, and performance. It's built as a web application using Python Flask with a modern web interface supporting multiple concurrent users.
 
+## AI / MCP integration
+
+Run LibreCrawl audits directly from AI assistants (Claude, Cursor, Codex) via [librecrawl-technical-seo-audit-mcp](https://github.com/adityaarsharma/librecrawl-technical-seo-audit-mcp) — an MIT-licensed [Model Context Protocol](https://modelcontextprotocol.io) server built on LibreCrawl. It exposes 37 MCP tools for adaptive crawl-delay control, WAF fingerprint detection, and automated PDF/CSV report generation, letting an AI agent crawl and audit a site conversationally. It's a wrapper around LibreCrawl, not a replacement.
+
 ## Features
 
 - 🚀 **Multi-tenancy** - Multiple users can crawl simultaneously with isolated sessions


### PR DESCRIPTION
Hi! Following up on your suggestion in [discussion #76](https://github.com/PhialsBasement/LibreCrawl/discussions/76) — *"why don't you just implement your suggestions and make a pull request?"* — here it is.

This adds a short **AI / MCP integration** section to the README linking to [librecrawl-technical-seo-audit-mcp](https://github.com/adityaarsharma/librecrawl-technical-seo-audit-mcp), an MIT-licensed Model Context Protocol server built on LibreCrawl. It lets AI assistants (Claude, Cursor, Codex) run LibreCrawl audits conversationally.

The wording positions it explicitly as a wrapper around LibreCrawl, not a replacement. Happy to adjust the placement or copy however you'd like. Thanks for building LibreCrawl! 🙏